### PR TITLE
Docker Setup for HemeLB: Ubuntu Focal (20.04), GCC-13, Conda, Python 3.8 Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Taking as base image a Ubuntu Desktop container with web-based noVNC connection enabled
 FROM dorowu/ubuntu-desktop-lxde-vnc
-MAINTAINER Miguel O. Bernabeu (miguel.bernabeu@ed.ac.uk)
+LABEL "CORE_MAINTAINER"="Miguel O. Bernabeu (miguel.bernabeu@ed.ac.uk)"
+LABEL "MAINTAINER"="Joyanta J. Mondal (joyanta@udel.edu)"
+LABEL version="1.1"
 
 ##
 # Dependencies
@@ -35,7 +37,7 @@ ENV PATH=$VMTKHOME/bin:$PATH \
 # Download and install HemeLB
 ##
 WORKDIR /tmp
-RUN git clone https://github.com/UCL/hemelb.git
+RUN git clone https://github.com/hemelb-codes/hemelb.git
 RUN mkdir hemelb/build && \
     cd hemelb/build && \
     cmake .. -DHEMELB_STEERING_LIB=none -DHEMELB_USE_SSE3=ON && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,35 @@ ENV PATH=$CONDA_DIR/bin:$PATH
 # -------------------------
 # Install system dependencies
 # -------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Fix missing Chrome GPG key BEFORE update
+RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+    > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
     wget curl git sudo gnupg2 software-properties-common \
     build-essential cmake cmake-curses-gui \
     libopenmpi-dev openmpi-bin \
-    libtinyxml-dev libboost-all-dev libcgal-dev \
+    libtinyxml-dev libboost-all-dev libcgal-dev libctemplate-dev \
     ca-certificates apt-transport-https lsb-release \
     xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
+# Set up GCC-13 from the Toolchain Test PPA manually
+RUN apt-get update && \
+    apt-get install -y software-properties-common gnupg2 wget && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA9EF27F && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    apt-get install -y gcc-13 g++-13 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+
+
+
 # -------------------------
-# Install Anaconda (Python 3.8.20)
+# Install Anaconda (For Python 3.8.20)
 # -------------------------
-RUN wget https://repo.anaconda.com/archive/Anaconda3-2023.09-1-Linux-x86_64.sh -O anaconda.sh && \
+    RUN wget https://repo.anaconda.com/archive/Anaconda3-2024.02-1-Linux-x86_64.sh -O anaconda.sh && \
     bash anaconda.sh -b -p $CONDA_DIR && \
     rm anaconda.sh && \
     $CONDA_DIR/bin/conda clean -afy
@@ -29,11 +45,14 @@ RUN wget https://repo.anaconda.com/archive/Anaconda3-2023.09-1-Linux-x86_64.sh -
 # -------------------------
 # Fix Chrome GPG and install Chrome
 # -------------------------
-RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
+    RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub -o /tmp/linux_signing_key.pub && \
+    gpg --dearmor --batch < /tmp/linux_signing_key.pub > /usr/share/keyrings/google-chrome.gpg && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
     > /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get update && apt-get install -y google-chrome-stable && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get update && \
+    apt-get install -y google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/* /tmp/linux_signing_key.pub
+
 
 # -------------------------
 # Clone and build HemeLB
@@ -42,34 +61,44 @@ WORKDIR /opt
 RUN git clone https://github.com/lepotatoguy/hemelb.git && \
     cd hemelb && \
     git checkout 5647f6d && \
-    mkdir build && cd build && \
-    cmake .. && \
-    make && \
-    ln -s /opt/hemelb/build/hemelb /usr/local/bin/hemelb
+    mkdir build && cd build
+
+# Set working directory for subsequent build steps
+WORKDIR /opt/hemelb/build
+
+# First CMake run — will fail but download and prepare dependencies
+RUN cmake -DCMAKE_C_COMPILER=/usr/bin/gcc-13 \
+-DCMAKE_CXX_COMPILER=/usr/bin/g++-13 \
+ .. || true
+
+# Build only the ParMETIS external dependency
+RUN make dep_ParMETIS
+
+# OPTIONAL: Debug location of ParMETIS to verify build
+RUN find . -name "libparmetis.a" && find . -name "parmetis.h"
+
+# Re-run cmake now that ParMETIS is available, then build HemeLB
+RUN cmake -DCMAKE_C_COMPILER=/usr/bin/gcc-13 \
+-DCMAKE_CXX_COMPILER=/usr/bin/g++-13 \
+ .. && make
 
 # -------------------------
 # Build geometry-tool and Python environment
 # -------------------------
-WORKDIR /opt/hemelb/Tools/geometry-tool
-COPY hemelb-spec-2024-12-06.txt conda-environment.yml ./
-RUN conda env create -f conda-environment.yml && \
-    echo "source activate gmy-tool" >> ~/.bashrc && \
-    conda run -n gmy-tool conda install --yes --file hemelb-spec-2024-12-06.txt
+    WORKDIR /opt/hemelb/geometry-tool
+    # Install the environment
+    RUN conda env create -f conda-environment.yml && \
+        echo "source activate gmy-tool" >> ~/.bashrc && \
+        bash -c "source activate gmy-tool && conda install --yes --file /opt/hemelb/hemelb-spec-2024-12-06.txt"
+    
 
 # -------------------------
 # Install HemeLB python-tools and GUI geometry tool
 # -------------------------
-WORKDIR /opt/hemelb/Tools/python-tools
+WORKDIR /opt/hemelb/python-tools
 RUN conda run -n gmy-tool pip install . && \
     cd ../geometry-tool && \
     conda run -n gmy-tool pip install '.[gui]'
-
-# -------------------------
-# Environment setup
-# -------------------------
-ENV PATH="/opt/hemelb/Tools/geometry-tool:$PATH"
-ENV PYTHONPATH="/opt/hemelb/Tools/python-tools:/opt/hemelb/Tools/geometry-tool:$PYTHONPATH"
-
 # -------------------------
 # Provide data volume and working directory
 # -------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,9 +83,6 @@ RUN cmake -DCMAKE_C_COMPILER=/usr/bin/gcc-13 \
 # Build only the ParMETIS external dependency
 RUN make dep_ParMETIS
 
-# OPTIONAL: Debug location of ParMETIS to verify build
-RUN find . -name "libparmetis.a" && find . -name "parmetis.h"
-
 # Re-run cmake now that ParMETIS is available, then build HemeLB
 RUN cmake -DCMAKE_C_COMPILER=/usr/bin/gcc-13 \
 -DCMAKE_CXX_COMPILER=/usr/bin/g++-13 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM dorowu/ubuntu-desktop-lxde-vnc:focal
 LABEL "CORE_MAINTAINER"="Miguel O. Bernabeu (miguel.bernabeu@ed.ac.uk)"
 LABEL MAINTAINER="Joyanta J. Mondal (joyanta@udel.edu)"
 LABEL VERSION="2.0"
+# https://hub.docker.com/r/dorowu/ubuntu-desktop-lxde-vnc/
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CONDA_DIR=/opt/conda
@@ -20,7 +21,8 @@ RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor
     libopenmpi-dev openmpi-bin \
     libtinyxml-dev libboost-all-dev libcgal-dev libctemplate-dev \
     ca-certificates apt-transport-https lsb-release \
-    xz-utils && \
+    xz-utils jq && \
+    apt-get install -y libopengl0 libxt6 libosmesa6 libglx0 python3-wxgtk4.0 &&\
     rm -rf /var/lib/apt/lists/*
 
 # Set up GCC-13 from the Toolchain Test PPA manually
@@ -33,12 +35,14 @@ RUN apt-get update && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
 
+# RUN apt-get install gcc-9 
+
 
 
 # -------------------------
 # Install Anaconda (For Python 3.8.20)
 # -------------------------
-    RUN wget https://repo.anaconda.com/archive/Anaconda3-2024.02-1-Linux-x86_64.sh -O anaconda.sh && \
+RUN wget https://repo.anaconda.com/archive/Anaconda3-2024.02-1-Linux-x86_64.sh -O anaconda.sh && \
     bash anaconda.sh -b -p $CONDA_DIR && \
     rm anaconda.sh && \
     $CONDA_DIR/bin/conda clean -afy
@@ -46,7 +50,7 @@ RUN apt-get update && \
 # -------------------------
 # Fix Chrome GPG and install Chrome
 # -------------------------
-    RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub -o /tmp/linux_signing_key.pub && \
+RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub -o /tmp/linux_signing_key.pub && \
     gpg --dearmor --batch < /tmp/linux_signing_key.pub > /usr/share/keyrings/google-chrome.gpg && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
     > /etc/apt/sources.list.d/google-chrome.list && \
@@ -86,9 +90,9 @@ RUN cmake -DCMAKE_C_COMPILER=/usr/bin/gcc-13 \
 # -------------------------
 # Build geometry-tool and Python environment
 # -------------------------
-    WORKDIR /opt/hemelb/geometry-tool
-    # Install the environment
-    RUN conda env create -f conda-environment.yml && \
+WORKDIR /opt/hemelb/geometry-tool
+# Install the environment
+RUN conda env create -f conda-environment.yml && \
         echo "source activate gmy-tool" >> ~/.bashrc && \
         bash -c "source activate gmy-tool && conda install --yes --file /opt/hemelb/hemelb-spec-2024-12-06.txt"
     
@@ -104,7 +108,7 @@ RUN conda run -n gmy-tool pip install . && \
 # -------------------------
 # Install gevent for web 
 # -------------------------
-    RUN apt-get update && apt-get install -y python3-pip && pip3 install gevent gevent-websocket
+RUN apt-get update && apt-get install -y python3-pip && pip3 install gevent gevent-websocket
 
 # -------------------------
 # Provide data volume and working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM dorowu/ubuntu-desktop-lxde-vnc:focal
+LABEL "CORE_MAINTAINER"="Miguel O. Bernabeu (miguel.bernabeu@ed.ac.uk)"
 LABEL MAINTAINER="Joyanta J. Mondal (joyanta@udel.edu)"
 LABEL VERSION="2.0"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,12 @@ WORKDIR /opt/hemelb/python-tools
 RUN conda run -n gmy-tool pip install . && \
     cd ../geometry-tool && \
     conda run -n gmy-tool pip install '.[gui]'
+
+# -------------------------
+# Install gevent for web 
+# -------------------------
+    RUN apt-get update && apt-get install -y python3-pip && pip3 install gevent gevent-websocket
+
 # -------------------------
 # Provide data volume and working directory
 # -------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,14 @@ RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub -o /tmp/linux_s
 # Clone and build HemeLB
 # -------------------------
 WORKDIR /opt
-RUN git clone https://github.com/lepotatoguy/hemelb.git && \
+RUN git clone --branch development --single-branch https://github.com/lepotatoguy/hemelb.git && \
     cd hemelb && \
-    git checkout 5647f6d && \
+    git checkout 787b584 && \
     mkdir build && cd build
+
+# Patch geometry.h to include cstdint
+RUN sed -i '1i#include <cstdint>' /opt/hemelb/Code/io/formats/geometry.h
+
 
 # Set working directory for subsequent build steps
 WORKDIR /opt/hemelb/build
@@ -94,7 +98,7 @@ WORKDIR /opt/hemelb/geometry-tool
 # Install the environment
 RUN conda env create -f conda-environment.yml && \
         echo "source activate gmy-tool" >> ~/.bashrc && \
-        bash -c "source activate gmy-tool && conda install --yes --file /opt/hemelb/hemelb-spec-2024-12-06.txt"
+        bash -c "source activate gmy-tool && conda install --yes --file /opt/hemelb/hemelb-geometry-python-env.txt"
     
 
 # -------------------------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the HemeLB setup tool.
 
 Build the container with: `docker build -t hemelb .`
 
-Launch the container with: `docker run -i -t -p 6080:6080 -v <path_to_your_data>:/data  hemelb`,
+Launch the container with: `docker run -i -t -p 6080:80 -v <path_to_your_data>:/data  hemelb`,
 where `<path_to_your_data>` is the folder in the host system that you want to mount as `/data` in the container.
 
 The path of your data should include:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Build the container with: `docker build -t hemelb .`
 Launch the container with: `docker run -i -t -p 6080:6080 -v <path_to_your_data>:/data  hemelb`,
 where `<path_to_your_data>` is the folder in the host system that you want to mount as `/data` in the container.
 
-
-
 The path of your data should include:
 - .stl file
 - .xml file
@@ -17,10 +15,7 @@ The path of your data should include:
 - .pr2 file (if any)
 
 Example command: 
-docker run -it --rm \      
-  -p 6080:80 \
-  -v /home/joyanta/hemelb/hemelb-experiments/large_cylinder_default/input:/data \
-  hemelb
+`docker run -it -p 6080:80 -v /home/joyanta/hemelb/hemelb-experiments/large_cylinder_default/input:/data hemelb`
 
 When running the container via boot2docker (e.g. OS X, Windows): Connect with
 your browser to the boot2docker VM on port 6080, i.e. `http://192.168.99.100:6080`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Build the container with: `docker build -t hemelb .`
 Launch the container with: `docker run -i -t -p 6080:6080 -v <path_to_your_data>:/data  hemelb`,
 where `<path_to_your_data>` is the folder in the host system that you want to mount as `/data` in the container.
 
+
+
+The path of your data should include:
+- .stl file
+- .xml file
+- .gmy file (if any)
+- .pr2 file (if any)
+
+Example command: 
+docker run -it --rm \      
+  -p 6080:80 \
+  -v /home/joyanta/hemelb/hemelb-experiments/large_cylinder_default/input:/data \
+  hemelb
+
 When running the container via boot2docker (e.g. OS X, Windows): Connect with
 your browser to the boot2docker VM on port 6080, i.e. `http://192.168.99.100:6080`
 


### PR DESCRIPTION
Summary:

This pull request modernizes the Docker build setup for HemeLB and transitions the default branch naming convention from "master" to "main".

The Docker environment is updated from an outdated Ubuntu 14.04 setup to a modern Ubuntu 20.04 base. Major toolchain upgrades and Python environment improvements are incorporated to ensure compatibility with contemporary software ecosystems.

As part of modern best practices, I renamed the default branch from "master" to "main". This pull request contains the initial setup and transition to "main".

Key Changes:

- Updated base image to dorowu/ubuntu-desktop-lxde-vnc:focal.

- Introduced GCC 13 from the Ubuntu Toolchain PPA for modern C++ support.

- Migrated from system Python 2.7 dependencies to a Conda-based Python 3.8 environment.

- Fixed deprecated or broken package installation steps (Chrome GPG keys).

- Installed HemeLB Python tools and the geometry GUI tool through Conda.

- Transitioned repository default branch from master to main.